### PR TITLE
Add AWS VPC data source and update subnet filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
-
+.idea
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc

--- a/data.tf
+++ b/data.tf
@@ -1,4 +1,15 @@
+data "aws_vpc" "base_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["Base VPC"]
+  }
+}
+
 data "aws_subnet" "private_subnet_1" {
+  filter {
+    name   = "vpc_id"
+    values = [data.aws_vpc.base_vpc.id]
+  }
   filter {
     name   = "tag:Name"
     values = ["PrivateSubnet1"]
@@ -7,14 +18,11 @@ data "aws_subnet" "private_subnet_1" {
 
 data "aws_subnet" "private_subnet_2" {
   filter {
-    name   = "tag:Name"
-    values = ["PrivateSubnet2"]
+    name   = "vpc_id"
+    values = [data.aws_vpc.base_vpc.id]
   }
-}
-
-data "aws_vpc" "base_vpc" {
   filter {
     name   = "tag:Name"
-    values = ["Base VPC"]
+    values = ["PrivateSubnet2"]
   }
 }

--- a/data.tf
+++ b/data.tf
@@ -1,28 +1,28 @@
 data "aws_vpc" "base_vpc" {
   filter {
-    name   = "tag:Name"
-    values = ["Base VPC"]
+    name = "tag:Name"
+    values = ["BaseVPC"]
   }
 }
 
 data "aws_subnet" "private_subnet_1" {
   filter {
-    name   = "vpc_id"
+    name = "vpc_id"
     values = [data.aws_vpc.base_vpc.id]
   }
   filter {
-    name   = "tag:Name"
+    name = "tag:Name"
     values = ["PrivateSubnet1"]
   }
 }
 
 data "aws_subnet" "private_subnet_2" {
   filter {
-    name   = "vpc_id"
+    name = "vpc_id"
     values = [data.aws_vpc.base_vpc.id]
   }
   filter {
-    name   = "tag:Name"
+    name = "tag:Name"
     values = ["PrivateSubnet2"]
   }
 }


### PR DESCRIPTION
Moved the AWS VPC data source definition to the top of data.tf and updated the subnet filters to depend on the VPC ID. Also, added .idea directory to .gitignore for IDE-specific files.